### PR TITLE
Use PR abbreviation for requisition points

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 <div class="info-box"><strong>Faction de Croisade:</strong> <input type="text" id="crusade-faction" placeholder="Ex: Imperium"></div>
                 <div class="info-box">
                     <strong>Points de Réquisition:</strong>
-                    <span id="pr-points" class="stat-value"></span> RP
+                    <span id="pr-points" class="stat-value"></span> PR
                     <button class="tally-btn" data-action="decrease-rp">-</button>
                     <button class="tally-btn" data-action="increase-rp">+</button>
                 </div>
@@ -77,7 +77,7 @@
                     <div style="display: flex; align-items: center; gap: 8px; margin-top: 4px;">
                         <input type="number" id="supply-limit" min="0" style="width: 80px; display: inline-block;">
                         <span>PL</span>
-                        <button id="increase-supply-limit-btn" class="tally-btn" title="Augmenter la limite de 200 PL pour 1 RP" style="margin-left: auto;">+200</button>
+                        <button id="increase-supply-limit-btn" class="tally-btn" title="Augmenter la limite de 200 PL pour 1 PR" style="margin-left: auto;">+200</button>
                     </div>
                 </div>
                 <div class="info-box">
@@ -110,7 +110,7 @@
                         <strong>Sainte Potentia Actuelle:</strong>
                         <span id="saint-potentia-name">Aucune</span>
                         <button id="select-saint-btn" class="btn-secondary">Choisir</button>
-                        <button id="change-saint-btn" class="btn-danger">Changer (1 RP)</button>
+                        <button id="change-saint-btn" class="btn-danger">Changer (1 PR)</button>
                     </div>
                     <div class="info-box">
                         <label for="active-trial-select"><strong>Épreuve Active:</strong></label>
@@ -469,7 +469,7 @@
                             </div>
                             <hr>
                             <button type="submit" class="btn-primary">Valider les Changements</button>
-                            <button type="button" id="randomize-planet-btn" class="btn-secondary" style="margin-left: 10px;">Randomiser Planète (2 RP)</button>
+                            <button type="button" id="randomize-planet-btn" class="btn-secondary" style="margin-left: 10px;">Randomiser Planète (2 PR)</button>
                         </div>
                     </div>
                 </details>
@@ -594,7 +594,7 @@
                 <button id="exploration-choice-cancel-btn" class="btn-secondary">Annuler</button>
                 <div style="display: flex; gap: 10px; flex-wrap: wrap;">
                     <button id="exploration-choice-blind-jump-btn" class="btn-primary">Saut à l'aveugle</button>
-                    <button id="exploration-choice-probe-btn" class="btn-primary">Envoyer la sonde (1 RP)</button>
+                    <button id="exploration-choice-probe-btn" class="btn-primary">Envoyer la sonde (1 PR)</button>
                 </div>
             </div>
         </div>
@@ -609,7 +609,7 @@
                 <button id="route-discovery-choice-cancel-btn" class="btn-secondary">Annuler</button>
                 <div style="display: flex; gap: 10px; flex-wrap: wrap;">
                     <button id="route-discovery-choice-map-btn" class="btn-primary">Cartographier la Route</button>
-                    <button id="route-discovery-choice-probe-btn" class="btn-primary">Envoyer la sonde (1 RP)</button>
+                    <button id="route-discovery-choice-probe-btn" class="btn-primary">Envoyer la sonde (1 PR)</button>
                 </div>
             </div>
         </div>
@@ -622,7 +622,7 @@
             <p id="probe-action-text" style="line-height: 1.6;"></p>
             <p id="probe-action-timer" style="line-height: 1.6; color: var(--text-muted-color); font-style: italic;"></p>
             <div class="modal-actions" style="justify-content: space-between; flex-wrap: wrap;">
-                <button id="probe-action-rescan-btn" class="btn-secondary">Relancer une sonde (1 RP)</button>
+                <button id="probe-action-rescan-btn" class="btn-secondary">Relancer une sonde (1 PR)</button>
                 <div style="display: flex; gap: 10px; flex-wrap: wrap;">
                     <button id="probe-action-cancel-btn" class="btn-secondary">Annuler</button>
                     <button id="probe-action-establish-btn" class="btn-primary">Établir le lien</button>


### PR DESCRIPTION
## Summary
- display requisition points using the "PR" abbreviation
- update related buttons and tooltips to replace "RP" with "PR"

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689649e7146483328216a78a9bd32448