### PR TITLE
feat: online backup option

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -819,3 +819,24 @@ const handleImport = (event) => {
     reader.readAsText(file);
     event.target.value = null; // Permet de ré-importer le même fichier
 };
+
+
+/**
+ * Envoie les données de la campagne vers un serveur pour une sauvegarde en ligne.
+ */
+const handleOnlineBackup = async () => {
+    try {
+        const response = await fetch('https://example.com/api/backup', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(campaignData)
+        });
+        if (!response.ok) {
+            throw new Error('Réponse réseau non satisfaisante');
+        }
+        showNotification("Sauvegarde en ligne réussie !", 'success');
+    } catch (error) {
+        console.error('Erreur lors de la sauvegarde en ligne :', error);
+        showNotification("Erreur de sauvegarde en ligne.", 'error');
+    }
+};

--- a/index.html
+++ b/index.html
@@ -17,11 +17,12 @@
             <div class="campaign-controls">
                 <button id="export-btn">Exporter la Campagne (JSON)</button>
                 <button id="import-btn">Importer la Campagne (JSON)</button>
+                <button id="online-backup-btn">Sauvegarder en Ligne</button>
                 <input type="file" id="import-file" accept=".json" style="display: none;">
             </div>
             <p class="storage-warning">
               ⚠️ **Attention :** Toutes les données sont sauvegardées localement dans votre navigateur.
-                Utilisez l'export pour créer des sauvegardes !
+                Utilisez l'export ou la sauvegarde en ligne pour créer des sauvegardes !
             </p>
             <div class="management-controls">
                 <button id="reset-campaign-btn" class="btn-danger">Explosion du Warp (Réinitialiser)</button>

--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const exportBtn = document.getElementById('export-btn');
     const importBtn = document.getElementById('import-btn');
     const importFile = document.getElementById('import-file');
+    const onlineBackupBtn = document.getElementById('online-backup-btn');
     const resetCampaignBtn = document.getElementById('reset-campaign-btn');
     mapModal = document.getElementById('map-modal');
     const mapContainer = document.getElementById('galactic-map-container');
@@ -53,6 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
     exportBtn.addEventListener('click', handleExport);
     importBtn.addEventListener('click', () => importFile.click());
     importFile.addEventListener('change', handleImport);
+    onlineBackupBtn.addEventListener('click', handleOnlineBackup);
     backToListBtn.addEventListener('click', () => switchView('list'));
 
     backToSystemBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add online backup button to allow saving campaign to remote server
- wire new button to `handleOnlineBackup` event
- implement `handleOnlineBackup` using `fetch` to send data to server

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689703c89cdc8332af196f9de7bbb7b4