### PR TITLE
Move campaign rules comparison to player list menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,11 +493,6 @@
             <span class="close-btn">&times;</span>
             <h3 class="crusade-card-title">Carte Galactique</h3>
 
-            <div class="map-modal-tabs">
-                <button class="tab-link active" data-tab="map-content-panel">Carte</button>
-                <button class="tab-link" data-tab="info-content-panel">Regles Adapter pour la campagne</button>
-            </div>
-
             <div id="map-content-panel" class="map-modal-content-panel active">
                 <div class="map-controls">
                     <label for="map-player-view-select">Point de vue :</label>
@@ -516,9 +511,14 @@
                 <div id="galactic-map-container">
                 </div>
             </div>
+        </div>
+    </div>
 
-            <div id="info-content-panel" class="map-modal-content-panel hidden">
-                </div>
+    <div id="campaign-rules-modal" class="modal hidden">
+        <div class="modal-content large">
+            <span class="close-btn">&times;</span>
+            <h3 class="crusade-card-title">Comparaison des Règles</h3>
+            <div id="campaign-rules-content"></div>
         </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const mapContainer = document.getElementById('galactic-map-container');
     const npcCombatModal = document.getElementById('npc-combat-modal');
     const pvpCombatModal = document.getElementById('pvp-combat-modal');
+    const campaignRulesModal = document.getElementById('campaign-rules-modal');
     
     const actionLogContainer = document.getElementById('action-log-container');
     const actionLogHeader = document.getElementById('action-log-header');
@@ -129,6 +130,11 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 showNotification("Erreur : ce joueur n'a pas de système assigné.", 'error');
             }
+        } else if (target.matches('.rules-btn')) {
+            const playerIndex = parseInt(target.dataset.index);
+            const player = campaignData.players[playerIndex];
+            renderCampaignRules(player.id);
+            openModal(campaignRulesModal);
         } else if (target.matches('.delete-player-btn')) {
             const index = parseInt(target.dataset.index);
             const playerToDelete = campaignData.players[index];
@@ -687,7 +693,6 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.target.id === 'show-map-btn') {
             openModal(mapModal);
             currentMapScale = 1;
-        renderCampaignRulesTab(); 
             setTimeout(renderGalacticMap, 50);
         } else if (e.target.id === 'show-history-btn') {
             openFullHistoryModal();
@@ -943,18 +948,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         displayPendingNotifications();
         renderActionLog();
-    });
-
-    document.querySelector('.map-modal-tabs').addEventListener('click', (e) => {
-        if (e.target.classList.contains('tab-link')) {
-            const targetTab = e.target.dataset.tab;
-
-            document.querySelectorAll('#map-modal .tab-link').forEach(tab => tab.classList.remove('active'));
-            document.querySelectorAll('#map-modal .map-modal-content-panel').forEach(panel => panel.classList.add('hidden'));
-            
-            e.target.classList.add('active');
-            document.getElementById(targetTab).classList.remove('hidden');
-        }
     });
 
     document.getElementById('unit-name').addEventListener('change', (e) => {

--- a/render.js
+++ b/render.js
@@ -60,6 +60,7 @@ const renderPlayerList = () => {
                 <button class="btn-secondary edit-player-btn" data-index="${index}">Modifier</button>
                 <button class="btn-danger delete-player-btn" data-index="${index}">Supprimer</button>
                 <button class="btn-secondary world-btn" data-index="${index}">JOUER</button>
+                <button class="btn-secondary rules-btn" data-index="${index}">Comparer</button>
             </div>
         `;
         playerListDiv.appendChild(card);
@@ -843,27 +844,25 @@ const renderActionLog = () => {
 };
 
 /**
- * Remplit l'onglet des règles de campagne adaptées dans la modale de la carte.
+ * Affiche la comparaison entre les règles officielles et leur implémentation.
+ * @param {string} playerId - ID du joueur pour lequel afficher les données.
  */
-function renderCampaignRulesTab() {
-    const infoPanel = document.getElementById('info-content-panel');
-    infoPanel.innerHTML = ''; // Vider le contenu précédent
-    const player = campaignData.players.find(p => p.id === mapViewingPlayerId);
+function renderCampaignRules(playerId) {
+    const infoPanel = document.getElementById('campaign-rules-content');
+    infoPanel.innerHTML = '';
+    const player = campaignData.players.find(p => p.id === playerId);
 
     if (!player || !campaignRuleDifferences) {
         infoPanel.innerHTML = `<p>Aucune donnée de règle de campagne à afficher.</p>`;
         return;
     }
-    
+
     // Pour l'instant, on se concentre sur la Death Guard, mais la structure est prête pour d'autres factions.
     let factionKey;
     if (player.faction === 'Death Guard') {
         factionKey = 'deathGuard';
-    } 
+    }
     // Ajoutez d'autres 'else if' ici pour d'autres factions à l'avenir
-    // else if (player.faction === 'Tyranids') {
-    //     factionKey = 'tyranids';
-    // }
 
     const rulesData = campaignRuleDifferences[factionKey];
 
@@ -912,6 +911,6 @@ function renderCampaignRulesTab() {
             </div>
         </div>
     `;
-    
+
     infoPanel.innerHTML = tableHTML;
 }


### PR DESCRIPTION
## Summary
- Add "Comparer" button in player list that opens a dedicated modal showing official vs program rule differences.
- Remove rule comparison tab from galactic map and render comparison in new `campaign-rules-modal`.
- Wire up JavaScript handlers and renderer to populate the new modal.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689712c89c708332809538df3955e163