### PR TITLE
Reset probed systems on galaxy reset

### DIFF
--- a/main.js
+++ b/main.js
@@ -1006,7 +1006,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 };
                 playerSystems.push(newSystem);
                 player.systemId = newSystemId;
-                player.discoveredSystemIds = [newSystemId]; 
+                player.discoveredSystemIds = [newSystemId];
+                player.probedSystemIds = [];
             });
     
             campaignData.systems.push(...playerSystems);


### PR DESCRIPTION
## Summary
- Reset each player's `probedSystemIds` when generating a new galaxy
- Confirm data is saved and player list re-rendered after the reset

## Testing
- `node --check main.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68971745c704833286817724875a87b6