### PR TITLE
feat: add UUID generator

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -4,6 +4,18 @@
 
 const APP_VERSION = "0.1.4"; // Version avec historique d'actions par joueur
 
+// Génère un identifiant unique compatible anciens navigateurs
+function generateId() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = Math.random() * 16 | 0;
+        const v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
 //======================================================================
 //  ÉTAT DE L'APPLICATION (STATE)
 //======================================================================

--- a/galaxy.js
+++ b/galaxy.js
@@ -45,7 +45,7 @@ const generateRandomNPCSystem = (usedNames) => {
     const planets = [];
     for (let i = 0; i < numPlanets; i++) {
         planets.push({
-            id: crypto.randomUUID(), // Chaque planète a un ID unique
+            id: generateId(), // Chaque planète a un ID unique
             type: getWeightedRandomPlanetType(),
             name: `${planetNames[i] || `Planète ${i + 1}`}`,
             owner: "neutral",
@@ -53,7 +53,7 @@ const generateRandomNPCSystem = (usedNames) => {
         });
     }
     return {
-        id: crypto.randomUUID(),
+        id: generateId(),
         name: getUniqueSystemName(usedNames),
         owner: 'npc',
         planets: planets,

--- a/main.js
+++ b/main.js
@@ -159,14 +159,14 @@ document.addEventListener('DOMContentLoaded', () => {
             player.name = name;
             player.faction = document.getElementById('player-faction-input').value.trim();
         } else {
-            const newPlayerId = crypto.randomUUID();
-            const newSystemId = crypto.randomUUID();
+            const newPlayerId = generateId();
+            const newSystemId = generateId();
             const faction = document.getElementById('player-faction-input').value.trim();
             const DEFENSE_VALUES = [500, 1000, 1500, 2000];
             const planetNames = ["Prima", "Secundus", "Tertius", "Quartus", "Quintus", "Sextus", "Septimus", "Octavus"];
             const numPlanets = 5;
             const newPlanets = Array.from({ length: numPlanets }, (_, i) => ({
-                id: crypto.randomUUID(),
+                id: generateId(),
                 type: i === 0 ? "Monde Sauvage" : getWeightedRandomPlanetType(),
                 name: planetNames[i] || `Planète ${i + 1}`,
                 owner: i === 0 ? newPlayerId : "neutral",
@@ -465,7 +465,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const existingUnit = player.units[editingUnitIndex];
             player.units[editingUnitIndex] = { ...existingUnit, ...unitData };
         } else {
-            unitData.id = crypto.randomUUID();
+            unitData.id = generateId();
             unitData.detachmentUpgrades = [];
             player.units.push(unitData);
             logAction(player.id, `Nouvelle unité ajoutée à l'ordre de bataille : <b>${unitData.name}</b>.`, 'info', '➕');
@@ -987,12 +987,12 @@ document.addEventListener('DOMContentLoaded', () => {
             campaignData.players.forEach(player => {
                 player.actionLog = [];
     
-                const newSystemId = crypto.randomUUID();
+                const newSystemId = generateId();
                 const DEFENSE_VALUES = [500, 1000, 1500, 2000];
                 const planetNames = ["Prima", "Secundus", "Tertius", "Quartus", "Quintus", "Sextus", "Septimus", "Octavus"];
                 const numPlanets = 5;
                 const newPlanets = Array.from({ length: numPlanets }, (_, i) => ({
-                    id: crypto.randomUUID(),
+                    id: generateId(),
                     type: i === 0 ? "Monde Sauvage" : getWeightedRandomPlanetType(),
                     name: planetNames[i] || `Planète ${i + 1}`,
                     owner: i === 0 ? player.id : "neutral",


### PR DESCRIPTION
## Summary
- add `generateId` helper with Math.random fallback
- replace `crypto.randomUUID` calls with `generateId`
- verify warp reset works without `crypto.randomUUID`

## Testing
- `node` warp-explosion simulation without `crypto.randomUUID`

------
https://chatgpt.com/codex/tasks/task_e_6897192bc60083328153657ccc5e9ff2