### PR TITLE
The 'Sauvegarder en Ligne' (Online Backup) button was non-functional …

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -834,21 +834,40 @@ const handleImport = (event) => {
 
 
 /**
- * Envoie les données de la campagne vers un serveur pour une sauvegarde en ligne.
+ * Copie les données de la campagne dans le presse-papiers.
  */
 const handleOnlineBackup = async () => {
     try {
-        const response = await fetch('https://example.com/api/backup', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(campaignData)
-        });
-        if (!response.ok) {
-            throw new Error('Réponse réseau non satisfaisante');
-        }
-        showNotification("Sauvegarde en ligne réussie !", 'success');
+        const dataStr = JSON.stringify(campaignData, null, 2);
+        await navigator.clipboard.writeText(dataStr);
+        showNotification("Données de la campagne copiées dans le presse-papiers !", 'success');
     } catch (error) {
-        console.error('Erreur lors de la sauvegarde en ligne :', error);
-        showNotification("Erreur de sauvegarde en ligne.", 'error');
+        console.error('Erreur lors de la copie dans le presse-papiers :', error);
+        showNotification("Erreur lors de la copie des données.", 'error');
+    }
+};
+
+const handleLoadFromClipboard = async () => {
+    const pasteData = prompt("Veuillez coller vos données de sauvegarde ici :");
+    if (pasteData === null || pasteData.trim() === "") {
+        return;
+    }
+
+    try {
+        const importedData = JSON.parse(pasteData);
+        if (importedData && Array.isArray(importedData.players)) {
+            if (await showConfirm("Confirmation d'importation", "Importer ces données écrasera les données actuelles de la campagne. Êtes-vous sûr de vouloir continuer ?")) {
+                campaignData = importedData;
+                migrateData();
+                saveData();
+                renderPlayerList();
+                switchView('list');
+                showNotification("Importation depuis le presse-papiers réussie !", 'success');
+            }
+        } else {
+            showNotification("Les données collées ne sont pas valides.", 'error');
+        }
+    } catch (error) {
+        showNotification("Erreur lors de la lecture des données : " + error.message, 'error');
     }
 };

--- a/index.html
+++ b/index.html
@@ -17,7 +17,8 @@
             <div class="campaign-controls">
                 <button id="export-btn">Exporter la Campagne (JSON)</button>
                 <button id="import-btn">Importer la Campagne (JSON)</button>
-                <button id="online-backup-btn">Sauvegarder en Ligne</button>
+                <button id="online-backup-btn">Copier la Sauvegarde</button>
+                <button id="load-from-clipboard-btn">Charger depuis le Presse-papiers</button>
                 <input type="file" id="import-file" accept=".json" style="display: none;">
             </div>
             <p class="storage-warning">

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const importBtn = document.getElementById('import-btn');
     const importFile = document.getElementById('import-file');
     const onlineBackupBtn = document.getElementById('online-backup-btn');
+    const loadFromClipboardBtn = document.getElementById('load-from-clipboard-btn');
     const resetCampaignBtn = document.getElementById('reset-campaign-btn');
     mapModal = document.getElementById('map-modal');
     const mapContainer = document.getElementById('galactic-map-container');
@@ -56,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
     importBtn.addEventListener('click', () => importFile.click());
     importFile.addEventListener('change', handleImport);
     onlineBackupBtn.addEventListener('click', handleOnlineBackup);
+    loadFromClipboardBtn.addEventListener('click', handleLoadFromClipboard);
     backToListBtn.addEventListener('click', () => switchView('list'));
 
     backToSystemBtn.addEventListener('click', () => {


### PR DESCRIPTION
…as it pointed to a placeholder URL. I have replaced this feature with a more robust clipboard-based backup and restore system.

Changes:
- The 'Sauvegarder en Ligne' button is now 'Copier la Sauvegarde' and copies the campaign data as a JSON string to the clipboard.
- A new 'Charger depuis le Presse-papiers' button has been added, which allows you to paste the JSON data to restore your campaign state.
- This approach removes the dependency on an external service, making the feature more reliable.